### PR TITLE
Do not let frmtdbuff overflow in nic_format_buff.

### DIFF
--- a/src/nwhois.c
+++ b/src/nwhois.c
@@ -137,6 +137,11 @@ int nic_format_buff(char *buff, int listn)
 		}
 		frmtdbuff[strlen(frmtdbuff)] = buff[ctr];
 		ctr++;
+		if (strlen(frmtdbuff) >= sizeof(frmtdbuff) - 1) {
+			/* frmtdbuff is full, do not let it overflow */
+			print_line("%s", frmtdbuff);
+			memset(frmtdbuff, '\0', sizeof(frmtdbuff));
+		}
 	}
 	if ( strlen(frmtdbuff) ) linetodo = 1;
 	return 0;


### PR DESCRIPTION
The WHOIS protocol is unencrypted and even benign servers may return lines longer than 128 characters. This aims to address Issue #4.