### PR TITLE
Avoid conflicting prototypes for file_open().

### DIFF
--- a/src/includes/iwhois.h
+++ b/src/includes/iwhois.h
@@ -29,7 +29,7 @@ int ip_format_buff();
 int linetodo;   /* This is used to symbolise to ip_format_buff() that there is a line still to format */
 char query[26];
 extern char outputfile[64];
-extern void file_open();
+extern int file_open();
 extern void file_close();
 
 char *ip_whois_hosts[] = {

--- a/src/includes/mailsearch.h
+++ b/src/includes/mailsearch.h
@@ -8,7 +8,7 @@ extern void sendData();
 extern int get_host();
 extern void tcp_sockdcon();
 extern char outputfile[64];
-extern void file_open();
+extern int file_open();
 extern void file_close();
 extern void print_line();
 extern int tcp_sock;

--- a/src/includes/nwhois.h
+++ b/src/includes/nwhois.h
@@ -15,7 +15,7 @@ char td[10];
 char query[128];
 int linetodo;   /* This is used to symbolise to nic_format_buff() that there is a line still to format */
 extern char outputfile[64];
-extern void file_open();
+extern int file_open();
 extern void file_close();
 
 

--- a/src/includes/subsearch.h
+++ b/src/includes/subsearch.h
@@ -9,7 +9,7 @@ extern void sendData();
 extern int get_host();
 extern void tcp_sockdcon();
 extern char outputfile[64];
-extern void file_open();
+extern int file_open();
 extern void file_close();
 extern void print_line();
 extern int tcp_sock;


### PR DESCRIPTION
Fixes https://bugs.debian.org/746769 .